### PR TITLE
Support for PostgreSQL 11

### DIFF
--- a/expected/pgsk.out
+++ b/expected/pgsk.out
@@ -1,0 +1,42 @@
+CREATE EXTENSION pg_stat_statements;
+CREATE EXTENSION pg_stat_kcache;
+-- dummy query
+SELECT 1 AS dummy;
+ dummy 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM pg_stat_kcache WHERE datname = current_database();
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM pg_stat_kcache_detail WHERE datname = current_database() AND query = 'SELECT $1 AS dummy';
+ count 
+-------
+     1
+(1 row)
+
+SELECT query, reads, reads_blks, writes, writes_blks FROM pg_stat_kcache_detail WHERE datname = current_database() AND query = 'SELECT $1 AS dummy';
+       query        | reads | reads_blks | writes | writes_blks 
+--------------------+-------+------------+--------+-------------
+ SELECT $1 AS dummy |     0 |          0 |      0 |           0
+(1 row)
+
+-- dummy table
+CREATE TABLE test AS SELECT i FROM generate_series(1, 1000) i;
+-- dummy query again
+SELECT count(*) FROM test;
+ count 
+-------
+  1000
+(1 row)
+
+SELECT user_time + system_time > 0 AS cpu_time_ok FROM pg_stat_kcache_detail WHERE datname = current_database() AND query = 'SELECT count(*) FROM test';
+ cpu_time_ok 
+-------------
+ t
+(1 row)
+

--- a/test/sql/pgsk.sql
+++ b/test/sql/pgsk.sql
@@ -1,0 +1,19 @@
+CREATE EXTENSION pg_stat_statements;
+CREATE EXTENSION pg_stat_kcache;
+
+-- dummy query
+SELECT 1 AS dummy;
+
+SELECT count(*) FROM pg_stat_kcache WHERE datname = current_database();
+
+SELECT count(*) FROM pg_stat_kcache_detail WHERE datname = current_database() AND query = 'SELECT $1 AS dummy';
+
+SELECT query, reads, reads_blks, writes, writes_blks FROM pg_stat_kcache_detail WHERE datname = current_database() AND query = 'SELECT $1 AS dummy';
+
+-- dummy table
+CREATE TABLE test AS SELECT i FROM generate_series(1, 1000) i;
+
+-- dummy query again
+SELECT count(*) FROM test;
+
+SELECT user_time + system_time > 0 AS cpu_time_ok FROM pg_stat_kcache_detail WHERE datname = current_database() AND query = 'SELECT count(*) FROM test';


### PR DESCRIPTION
In PostgreSQL 11, pg_stat_statements' query ID has been widened from 32 bits
to 64 bits. See commit cff440d368690f94fbda1a475277e90ea2263843 for more
information.

This PR is a WIP as I plan to use the new infrastructure to widen the hash value to 64 bits.

This should address issue #11 