### PR TITLE
Allow PG_CONFIG value to be found on command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 
 MODULE_big = pg_stat_kcache
 OBJS = pg_stat_kcache.o


### PR DESCRIPTION
Use conditional variable assignment operator with PG_CONFIG to be able to override pg_config location on command-line, like in pg_qualstat.