### PR TITLE
Fix a bug and update Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,39 +53,67 @@ pg_stat_kcache create several objects.
 pg_stat_kcache view
 -------------------
 
-+-------------+-------------------+-------------------------------------------------------------+
-| Name        | Type              | Description                                                 |
-+=============+===================+=============================================================+
-| datname     | name              | Name of the database                                        |
-+-------------+-------------------+-------------------------------------------------------------+
-| user_time   | double precision  | User CPU time used                                          |
-+-------------+-------------------+-------------------------------------------------------------+
-| system_time | double precision  | System CPU time used                                        |
-+-------------+-------------------+-------------------------------------------------------------+
-| minflts     | bigint            | Number of page reclaims (soft page faults)                  |
-+-------------+-------------------+-------------------------------------------------------------+
-| majflts     | bigint            | Number of page faults (hard page faults)                    |
-+-------------+-------------------+-------------------------------------------------------------+
-| nswaps      | bigint            | Number of swaps (unmaintained on GNU/Linux)                 |
-+-------------+-------------------+-------------------------------------------------------------+
-| reads       | bigint            | Number of bytes read by the filesystem layer                |
-+-------------+-------------------+-------------------------------------------------------------+
-| reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer            |
-+-------------+-------------------+-------------------------------------------------------------+
-| writes      | bigint            | Number of bytes written by the filesystem layer             |
-+-------------+-------------------+-------------------------------------------------------------+
-| writes_blks | bigint            | Number of 8K blocks written by the filesystem layer         |
-+-------------+-------------------+-------------------------------------------------------------+
-| msgsnds     | bigint            | Number of IPC messages sent (unmaintained on GNU/Linux)     |
-+-------------+-------------------+-------------------------------------------------------------+
-| msgrcvs     | bigint            | Number of IPC messages received (unmaintained on GNU/Linux) |
-+-------------+-------------------+-------------------------------------------------------------+
-| nsignals    | bigint            | Number of signals received (unmaintained on GNU/Linux)      |
-+-------------+-------------------+-------------------------------------------------------------+
-| nvcsws      | bigint            | Number of voluntary context switches                        |
-+-------------+-------------------+-------------------------------------------------------------+
-| nivcsws     | bigint            | Number of involuntary context switches                      |
-+-------------+-------------------+-------------------------------------------------------------+
++------------------+-------------------+-----------------------------------------------------+
+| Name             | Type              | Description                                         |
++==================+===================+=====================================================+
+| datname          | name              | Name of the database                                |
++------------------+-------------------+-----------------------------------------------------+
+| plan_user_time   | double precision  | User CPU time used                                  |
++------------------+-------------------+-----------------------------------------------------+
+| plan_system_time | double precision  | System CPU time used                                |
++------------------+-------------------+-----------------------------------------------------+
+| plan_minflts     | bigint            | Number of page reclaims (soft page faults)          |
++------------------+-------------------+-----------------------------------------------------+
+| plan_majflts     | bigint            | Number of page faults (hard page faults)            |
++------------------+-------------------+-----------------------------------------------------+
+| plan_nswaps      | bigint            | Number of swaps                                     |
++------------------+-------------------+-----------------------------------------------------+
+| plan_reads       | bigint            | Number of bytes read by the filesystem layer        |
++------------------+-------------------+-----------------------------------------------------+
+| plan_reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer    |
++------------------+-------------------+-----------------------------------------------------+
+| plan_writes      | bigint            | Number of bytes written by the filesystem layer     |
++------------------+-------------------+-----------------------------------------------------+
+| plan_writes_blks | bigint            | Number of 8K blocks written by the filesystem layer |
++------------------+-------------------+-----------------------------------------------------+
+| plan_msgsnds     | bigint            | Number of IPC messages sent                         |
++------------------+-------------------+-----------------------------------------------------+
+| plan_msgrcvs     | bigint            | Number of IPC messages received                     |
++------------------+-------------------+-----------------------------------------------------+
+| plan_nsignals    | bigint            | Number of signals received                          |
++------------------+-------------------+-----------------------------------------------------+
+| plan_nvcsws      | bigint            | Number of voluntary context switches                |
++------------------+-------------------+-----------------------------------------------------+
+| plan_nivcsws     | bigint            | Number of involuntary context switches              |
++------------------+-------------------+-----------------------------------------------------+
+| exec_user_time   | double precision  | User CPU time used                                  |
++------------------+-------------------+-----------------------------------------------------+
+| exec_system_time | double precision  | System CPU time used                                |
++------------------+-------------------+-----------------------------------------------------+
+| exec_minflts     | bigint            | Number of page reclaims (soft page faults)          |
++------------------+-------------------+-----------------------------------------------------+
+| exec_majflts     | bigint            | Number of page faults (hard page faults)            |
++------------------+-------------------+-----------------------------------------------------+
+| exec_nswaps      | bigint            | Number of swaps                                     |
++------------------+-------------------+-----------------------------------------------------+
+| exec_reads       | bigint            | Number of bytes read by the filesystem layer        |
++------------------+-------------------+-----------------------------------------------------+
+| exec_reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer    |
++------------------+-------------------+-----------------------------------------------------+
+| exec_writes      | bigint            | Number of bytes written by the filesystem layer     |
++------------------+-------------------+-----------------------------------------------------+
+| exec_writes_blks | bigint            | Number of 8K blocks written by the filesystem layer |
++------------------+-------------------+-----------------------------------------------------+
+| exec_msgsnds     | bigint            | Number of IPC messages sent                         |
++------------------+-------------------+-----------------------------------------------------+
+| exec_msgrcvs     | bigint            | Number of IPC messages received                     |
++------------------+-------------------+-----------------------------------------------------+
+| exec_nsignals    | bigint            | Number of signals received                          |
++------------------+-------------------+-----------------------------------------------------+
+| exec_nvcsws      | bigint            | Number of voluntary context switches                |
++------------------+-------------------+-----------------------------------------------------+
+| exec_nivcsws     | bigint            | Number of involuntary context switches              |
++------------------+-------------------+-----------------------------------------------------+
 
 pg_stat_kcache_detail view
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,15 @@ every database where you need to access the statistics::
 
  mydb=# CREATE EXTENSION pg_stat_kcache;
 
+Configuration
+=============
+
+The following GUCs can be configured, in ``postgresql.conf``:
+
+- *pg_stat_kcache.linux_hz* (int, default -1): informs pg_stat_kcache of the linux CONFIG_HZ config option. This is used by pg_stat_kcache to compensate for sampling errors. The default value is -1, tries to guess it at startup.
+- *pg_stat_kcache.track* (enum, default top): controls which statements are tracked by pg_stat_kcache. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection.
+- *pg_stat_kcache.track_planning* (bool, default off): controls whether planning operations and duration are tracked by pg_stat_kcache.
+
 Usage
 =====
 
@@ -53,136 +62,136 @@ pg_stat_kcache create several objects.
 pg_stat_kcache view
 -------------------
 
-+------------------+-------------------+-----------------------------------------------------+
-| Name             | Type              | Description                                         |
-+==================+===================+=====================================================+
-| datname          | name              | Name of the database                                |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_user_time   | double precision  | User CPU time used                                  |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_system_time | double precision  | System CPU time used                                |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_minflts     | bigint            | Number of page reclaims (soft page faults)          |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_majflts     | bigint            | Number of page faults (hard page faults)            |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nswaps      | bigint            | Number of swaps                                     |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_reads       | bigint            | Number of bytes read by the filesystem layer        |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer    |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_writes      | bigint            | Number of bytes written by the filesystem layer     |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_writes_blks | bigint            | Number of 8K blocks written by the filesystem layer |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_msgsnds     | bigint            | Number of IPC messages sent                         |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_msgrcvs     | bigint            | Number of IPC messages received                     |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nsignals    | bigint            | Number of signals received                          |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nvcsws      | bigint            | Number of voluntary context switches                |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nivcsws     | bigint            | Number of involuntary context switches              |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_user_time   | double precision  | User CPU time used                                  |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_system_time | double precision  | System CPU time used                                |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_minflts     | bigint            | Number of page reclaims (soft page faults)          |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_majflts     | bigint            | Number of page faults (hard page faults)            |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nswaps      | bigint            | Number of swaps                                     |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_reads       | bigint            | Number of bytes read by the filesystem layer        |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer    |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_writes      | bigint            | Number of bytes written by the filesystem layer     |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_writes_blks | bigint            | Number of 8K blocks written by the filesystem layer |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_msgsnds     | bigint            | Number of IPC messages sent                         |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_msgrcvs     | bigint            | Number of IPC messages received                     |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nsignals    | bigint            | Number of signals received                          |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nvcsws      | bigint            | Number of voluntary context switches                |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nivcsws     | bigint            | Number of involuntary context switches              |
-+------------------+-------------------+-----------------------------------------------------+
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+|       Name       |       Type       |                                                                       Description                                                                       |
++==================+==================+=========================================================================================================================================================+
+| datname          | name             | Name of the database                                                                                                                                    |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_user_time   | double precision | User CPU time used planning statements in this database, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)      |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_system_time | double precision | System CPU time used planning  statements in this database, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)   |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_minflts     | bigint           | Number of page reclaims (soft page faults) planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)          |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_majflts     | bigint           | Number of page faults (hard page faults) planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)            |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nswaps      | bigint           | Number of swaps planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)                                     |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_reads       | bigint           | Number of bytes read by the filesystem layer planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)        |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_reads_blks  | bigint           | Number of 8K blocks read by the filesystem layer planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)    |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_writes      | bigint           | Number of bytes written by the filesystem layer planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_writes_blks | bigint           | Number of 8K blocks written by the filesystem layer planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero) |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_msgsnds     | bigint           | Number of IPC messages sent planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)                         |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_msgrcvs     | bigint           | Number of IPC messages received planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)                     |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nsignals    | bigint           | Number of signals received planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)                          |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nvcsws      | bigint           | Number of voluntary context switches planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)                |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nivcsws     | bigint           | Number of involuntary context switches planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)              |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_user_time   | double precision | User CPU time used executing  statements in this database, in seconds and milliseconds                                                                  |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_system_time | double precision | System CPU time used executing  statements in this database, in seconds and milliseconds                                                                |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_minflts     | bigint           | Number of page reclaims (soft page faults) executing statements in this database                                                                        |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_majflts     | bigint           | Number of page faults (hard page faults) executing statements in this database                                                                          |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nswaps      | bigint           | Number of swaps executing statements in this database                                                                                                   |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_reads       | bigint           | Number of bytes read by the filesystem layer executing statements in this database                                                                      |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_reads_blks  | bigint           | Number of 8K blocks read by the filesystem layer executing statements in this database                                                                  |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_writes      | bigint           | Number of bytes written by the filesystem layer executing statements in this database                                                                   |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_writes_blks | bigint           | Number of 8K blocks written by the filesystem layer executing statements in this database                                                               |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_msgsnds     | bigint           | Number of IPC messages sent executing statements in this database                                                                                       |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_msgrcvs     | bigint           | Number of IPC messages received executing statements in this database                                                                                   |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nsignals    | bigint           | Number of signals received executing statements in this database                                                                                        |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nvcsws      | bigint           | Number of voluntary context switches executing statements in this database                                                                              |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nivcsws     | bigint           | Number of involuntary context switches executing statements in this database                                                                            |
++------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 pg_stat_kcache_detail view
 --------------------------
 
-+------------------+-------------------+-----------------------------------------------------+
-| Name             | Type              | Description                                         |
-+==================+===================+=====================================================+
-| query            | text              | Query text                                          |
-+------------------+-------------------+-----------------------------------------------------+
-| datname          | name              | Database name                                       |
-+------------------+-------------------+-----------------------------------------------------+
-| rolname          | name              | Role name                                           |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_user_time   | double precision  | User CPU time used                                  |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_system_time | double precision  | System CPU time used                                |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_minflts     | bigint            | Number of page reclaims (soft page faults)          |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_majflts     | bigint            | Number of page faults (hard page faults)            |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nswaps      | bigint            | Number of swaps                                     |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_reads       | bigint            | Number of bytes read by the filesystem layer        |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer    |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_writes      | bigint            | Number of bytes written by the filesystem layer     |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_writes_blks | bigint            | Number of 8K blocks written by the filesystem layer |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_msgsnds     | bigint            | Number of IPC messages sent                         |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_msgrcvs     | bigint            | Number of IPC messages received                     |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nsignals    | bigint            | Number of signals received                          |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nvcsws      | bigint            | Number of voluntary context switches                |
-+------------------+-------------------+-----------------------------------------------------+
-| plan_nivcsws     | bigint            | Number of involuntary context switches              |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_user_time   | double precision  | User CPU time used                                  |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_system_time | double precision  | System CPU time used                                |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_minflts     | bigint            | Number of page reclaims (soft page faults)          |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_majflts     | bigint            | Number of page faults (hard page faults)            |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nswaps      | bigint            | Number of swaps                                     |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_reads       | bigint            | Number of bytes read by the filesystem layer        |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_reads_blks  | bigint            | Number of 8K blocks read by the filesystem layer    |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_writes      | bigint            | Number of bytes written by the filesystem layer     |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_writes_blks | bigint            | Number of 8K blocks written by the filesystem layer |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_msgsnds     | bigint            | Number of IPC messages sent                         |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_msgrcvs     | bigint            | Number of IPC messages received                     |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nsignals    | bigint            | Number of signals received                          |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nvcsws      | bigint            | Number of voluntary context switches                |
-+------------------+-------------------+-----------------------------------------------------+
-| exec_nivcsws     | bigint            | Number of involuntary context switches              |
-+------------------+-------------------+-----------------------------------------------------+
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+|       Name       |       Type       |                                                               Description                                                                |
++==================+==================+==========================================================================================================================================+
+| query            | text             | Query text                                                                                                                               |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| datname          | name             | Database name                                                                                                                            |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| rolname          | name             | Role name                                                                                                                                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_user_time   | double precision | User CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_system_time | double precision | System CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)   |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_minflts     | bigint           | Number of page reclaims (soft page faults) planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)          |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_majflts     | bigint           | Number of page faults (hard page faults) planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)            |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nswaps      | bigint           | Number of swaps planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_reads       | bigint           | Number of bytes read by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)        |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_reads_blks  | bigint           | Number of 8K blocks read by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)    |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_writes      | bigint           | Number of bytes written by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_writes_blks | bigint           | Number of 8K blocks written by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero) |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_msgsnds     | bigint           | Number of IPC messages sent planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                         |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_msgrcvs     | bigint           | Number of IPC messages received planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nsignals    | bigint           | Number of signals received planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                          |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nvcsws      | bigint           | Number of voluntary context switches planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nivcsws     | bigint           | Number of involuntary context switches planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)              |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_user_time   | double precision | User CPU time used executing the statement, in seconds and milliseconds                                                                  |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_system_time | double precision | System CPU time used executing the statement, in seconds and milliseconds                                                                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_minflts     | bigint           | Number of page reclaims (soft page faults) executing the statements                                                                      |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_majflts     | bigint           | Number of page faults (hard page faults) executing the statements                                                                        |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nswaps      | bigint           | Number of swaps executing the statements                                                                                                 |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_reads       | bigint           | Number of bytes read by the filesystem layer executing the statements                                                                    |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_reads_blks  | bigint           | Number of 8K blocks read by the filesystem layer executing the statements                                                                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_writes      | bigint           | Number of bytes written by the filesystem layer executing the statements                                                                 |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_writes_blks | bigint           | Number of 8K blocks written by the filesystem layer executing the statements                                                             |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_msgsnds     | bigint           | Number of IPC messages sent executing the statements                                                                                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_msgrcvs     | bigint           | Number of IPC messages received executing the statements                                                                                 |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nsignals    | bigint           | Number of signals received executing the statements                                                                                      |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nvcsws      | bigint           | Number of voluntary context switches executing the statements                                                                            |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nivcsws     | bigint           | Number of involuntary context switches executing the statements                                                                          |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
 pg_stat_kcache_reset function
 -----------------------------
@@ -203,63 +212,71 @@ The function can be called by any user::
 
 It provides the following columns:
 
-+------------------+-------------------+--------------------------------------------------+
-| Name             | Type              | Description                                      |
-+==================+===================+==================================================+
-| queryid          | bigint            | pg_stat_statements' query identifier             |
-+------------------+-------------------+--------------------------------------------------+
-| userid           | oid               | Database OID                                     |
-+------------------+-------------------+--------------------------------------------------+
-| dbid             | oid               | Database OID                                     |
-+------------------+-------------------+--------------------------------------------------+
-| plan_user_time   | double precision  | User CPU time used                               |
-+------------------+-------------------+--------------------------------------------------+
-| plan_system_time | double precision  | System CPU time used                             |
-+------------------+-------------------+--------------------------------------------------+
-| plan_minflts     | bigint            | Number of page reclaims (soft page faults)       |
-+------------------+-------------------+--------------------------------------------------+
-| plan_majflts     | bigint            | Number of page faults (hard page faults)         |
-+------------------+-------------------+--------------------------------------------------+
-| plan_nswaps      | bigint            | Number of swaps                                  |
-+------------------+-------------------+--------------------------------------------------+
-| plan_reads       | bigint            | Number of bytes read by the filesystem layer     |
-+------------------+-------------------+--------------------------------------------------+
-| plan_writes      | bigint            | Number of bytes written by the filesystem layer  |
-+------------------+-------------------+--------------------------------------------------+
-| plan_msgsnds     | bigint            | Number of IPC messages sent                      |
-+------------------+-------------------+--------------------------------------------------+
-| plan_msgrcvs     | bigint            | Number of IPC messages received                  |
-+------------------+-------------------+--------------------------------------------------+
-| plan_nsignals    | bigint            | Number of signals received                       |
-+------------------+-------------------+--------------------------------------------------+
-| plan_nvcsws      | bigint            | Number of voluntary context switches             |
-+------------------+-------------------+--------------------------------------------------+
-| plan_nivcsws     | bigint            | Number of involuntary context switches           |
-+------------------+-------------------+--------------------------------------------------+
-| exec_user_time   | double precision  | User CPU time used                               |
-+------------------+-------------------+--------------------------------------------------+
-| exec_system_time | double precision  | System CPU time used                             |
-+------------------+-------------------+--------------------------------------------------+
-| exec_minflts     | bigint            | Number of page reclaims (soft page faults)       |
-+------------------+-------------------+--------------------------------------------------+
-| exec_majflts     | bigint            | Number of page faults (hard page faults)         |
-+------------------+-------------------+--------------------------------------------------+
-| exec_nswaps      | bigint            | Number of swaps                                  |
-+------------------+-------------------+--------------------------------------------------+
-| exec_reads       | bigint            | Number of bytes read by the filesystem layer     |
-+------------------+-------------------+--------------------------------------------------+
-| exec_writes      | bigint            | Number of bytes written by the filesystem layer  |
-+------------------+-------------------+--------------------------------------------------+
-| exec_msgsnds     | bigint            | Number of IPC messages sent                      |
-+------------------+-------------------+--------------------------------------------------+
-| exec_msgrcvs     | bigint            | Number of IPC messages received                  |
-+------------------+-------------------+--------------------------------------------------+
-| exec_nsignals    | bigint            | Number of signals received                       |
-+------------------+-------------------+--------------------------------------------------+
-| exec_nvcsws      | bigint            | Number of voluntary context switches             |
-+------------------+-------------------+--------------------------------------------------+
-| exec_nivcsws     | bigint            | Number of involuntary context switches           |
-+------------------+-------------------+--------------------------------------------------+
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+|       Name       |       Type       |                                                               Description                                                                |
++==================+==================+==========================================================================================================================================+
+| queryid          | bigint           | pg_stat_statements' query identifier                                                                                                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| userid           | oid              | Database OID                                                                                                                             |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| dbid             | oid              | Database OID                                                                                                                             |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_user_time   | double precision | User CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_system_time | double precision | System CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)   |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_minflts     | bigint           | Number of page reclaims (soft page faults) planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)          |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_majflts     | bigint           | Number of page faults (hard page faults) planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)            |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nswaps      | bigint           | Number of swaps planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_reads       | bigint           | Number of bytes read by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)        |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_reads_blks  | bigint           | Number of 8K blocks read by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)    |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_writes      | bigint           | Number of bytes written by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_writes_blks | bigint           | Number of 8K blocks written by the filesystem layer planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero) |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_msgsnds     | bigint           | Number of IPC messages sent planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                         |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_msgrcvs     | bigint           | Number of IPC messages received planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nsignals    | bigint           | Number of signals received planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                          |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nvcsws      | bigint           | Number of voluntary context switches planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_nivcsws     | bigint           | Number of involuntary context switches planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)              |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_user_time   | double precision | User CPU time used executing the statement, in seconds and milliseconds                                                                  |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_system_time | double precision | System CPU time used executing the statement, in seconds and milliseconds                                                                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_minflts     | bigint           | Number of page reclaims (soft page faults) executing the statements                                                                      |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_majflts     | bigint           | Number of page faults (hard page faults) executing the statements                                                                        |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nswaps      | bigint           | Number of swaps executing the statements                                                                                                 |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_reads       | bigint           | Number of bytes read by the filesystem layer executing the statements                                                                    |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_reads_blks  | bigint           | Number of 8K blocks read by the filesystem layer executing the statements                                                                |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_writes      | bigint           | Number of bytes written by the filesystem layer executing the statements                                                                 |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_writes_blks | bigint           | Number of 8K blocks written by the filesystem layer executing the statements                                                             |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_msgsnds     | bigint           | Number of IPC messages sent executing the statements                                                                                     |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_msgrcvs     | bigint           | Number of IPC messages received executing the statements                                                                                 |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nsignals    | bigint           | Number of signals received executing the statements                                                                                      |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nvcsws      | bigint           | Number of voluntary context switches executing the statements                                                                            |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| exec_nivcsws     | bigint           | Number of involuntary context switches executing the statements                                                                          |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
 Bugs and limitations
 ====================
@@ -277,6 +294,10 @@ On platforms without a native getrusage(2), all fields except `user_time` and
 On platforms with a native getrusage(2), some of the fields may not be
 maintained.  This is a platform dependent behavior, please refer to your
 platform getrusage(2) manual page for more details.
+
+If *pg_stat_kcache.track* is all, pg_stat_kcache tracks nested statements.
+Now, the max number of nesting level to track is 64 due to implement simpler and
+it should be enough for reasonable use cases.
 
 Authors
 =======

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -798,7 +798,7 @@ static pgskEntry *pgsk_entry_alloc(pgskHashKey *key)
 		/* New entry, initialize it */
 
 		/* reset the statistics */
-		memset(&entry->counters, 0, sizeof(pgskCounters));
+		memset(&entry->counters, 0, sizeof(pgskCounters) * PGSK_NUMKIND);
 		/* set the appropriate initial usage count */
 		entry->counters[0].usage = USAGE_INIT;
 		/* re-initialize the mutex each time ... we assume no one using it */


### PR DESCRIPTION
This PR is related to issue #24.

Fix a bug.
- pg_stat_kcache_reset() doesn't work correctly because the pgskCounters for execution is not initialized.

Update documentation.
- update the description of pg_stat_kcache view, plan_ and exec_ prefix columns, the new options and the limitations. 