### PR TITLE
Add a "top" column in pg_stat_kcache_detail view

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,8 @@ pg_stat_kcache_detail view
 +==================+==================+==========================================================================================================================================+
 | query            | text             | Query text                                                                                                                               |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| top              | bool             | True if the statement is top-level                                                                                                       |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | datname          | name             | Database name                                                                                                                            |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | rolname          | name             | Role name                                                                                                                                |
@@ -217,6 +219,8 @@ It provides the following columns:
 +==================+==================+==========================================================================================================================================+
 | queryid          | bigint           | pg_stat_statements' query identifier                                                                                                     |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| top              | bool             | True if the statement is top-level                                                                                                       |
++------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | userid           | oid              | Database OID                                                                                                                             |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | dbid             | oid              | Database OID                                                                                                                             |
@@ -298,6 +302,12 @@ platform getrusage(2) manual page for more details.
 If *pg_stat_kcache.track* is all, pg_stat_kcache tracks nested statements.
 Now, the max number of nesting level to track is 64 due to implement simpler and
 it should be enough for reasonable use cases.
+
+Even if *pg_stat_kcache.track* is all, pg_stat_kcache view considers only
+statistics of top-level statements. So, there is the case which even though
+user cpu time used planning a nested statement is high, `plan_user_time` of
+pg_stat_kcache view is small. In such a case, user cpu time used planning a
+nested statement is counted in `exec_user_time`.
 
 Authors
 =======

--- a/expected/pgsk.out
+++ b/expected/pgsk.out
@@ -46,3 +46,33 @@ AND query LIKE 'SELECT count(*) FROM test%';
  t
 (1 row)
 
+-- dummy nested query
+SET pg_stat_statements.track = 'all';
+SET pg_stat_statements.track_planning = TRUE;
+SET pg_stat_kcache.track = 'all';
+SET pg_stat_kcache.track_planning = TRUE;
+SELECT pg_stat_kcache_reset();
+ pg_stat_kcache_reset 
+----------------------
+ 
+(1 row)
+
+CREATE OR REPLACE FUNCTION plpgsql_nested()
+  RETURNS void AS $$
+BEGIN
+  PERFORM i::text as str from generate_series(1, 100) as i;
+  PERFORM md5(i::text) as str from generate_series(1, 100) as i;
+END
+$$ LANGUAGE plpgsql;
+SELECT plpgsql_nested();
+ plpgsql_nested 
+----------------
+ 
+(1 row)
+
+SELECT COUNT(*) FROM pg_stat_kcache_detail WHERE top IS FALSE;
+ count 
+-------
+     2
+(1 row)
+

--- a/pg_stat_kcache--2.2.0.sql
+++ b/pg_stat_kcache--2.2.0.sql
@@ -11,6 +11,7 @@ SET client_encoding = 'UTF8';
 
 CREATE FUNCTION pg_stat_kcache(
     OUT queryid bigint,
+    OUT top bool,
     OUT userid      oid,
     OUT dbid        oid,
     /* planning time */
@@ -52,7 +53,7 @@ CREATE FUNCTION pg_stat_kcache_reset()
 REVOKE ALL ON FUNCTION pg_stat_kcache_reset() FROM public;
 
 CREATE VIEW pg_stat_kcache_detail AS
-SELECT s.query, d.datname, r.rolname,
+SELECT s.query, k.top, d.datname, r.rolname,
        k.plan_user_time,
        k.plan_system_time,
        k.plan_minflts,
@@ -121,5 +122,6 @@ SELECT datname,
        SUM(exec_nvcsws) AS exec_nvcsws,
        SUM(exec_nivcsws) AS exec_nivcsws
   FROM pg_stat_kcache_detail
- GROUP BY datname;
+  WHERE top IS TRUE
+  GROUP BY datname;
 GRANT SELECT ON pg_stat_kcache TO public;

--- a/test/sql/pgsk.sql
+++ b/test/sql/pgsk.sql
@@ -23,3 +23,22 @@ SELECT exec_user_time + exec_system_time > 0 AS cpu_time_ok
 FROM pg_stat_kcache_detail
 WHERE datname = current_database()
 AND query LIKE 'SELECT count(*) FROM test%';
+
+-- dummy nested query
+SET pg_stat_statements.track = 'all';
+SET pg_stat_statements.track_planning = TRUE;
+SET pg_stat_kcache.track = 'all';
+SET pg_stat_kcache.track_planning = TRUE;
+SELECT pg_stat_kcache_reset();
+
+CREATE OR REPLACE FUNCTION plpgsql_nested()
+  RETURNS void AS $$
+BEGIN
+  PERFORM i::text as str from generate_series(1, 100) as i;
+  PERFORM md5(i::text) as str from generate_series(1, 100) as i;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT plpgsql_nested();
+
+SELECT COUNT(*) FROM pg_stat_kcache_detail WHERE top IS FALSE;


### PR DESCRIPTION
This patch is related to issue https://github.com/powa-team/pg_stat_kcache/issues/24.

If a nested query is executed, pg_stat_kcache didn't show expected
values for users because pg_stat_kcache view just accumulates all
values of pg_stat_kcache_detail view.

So, this patch add a "top" column in pg_stat_kcache_detail view
and pg_stat_kcache view accumates values of top-level statements.