### PR TITLE
change from PG_CATCH() to PG_FINALLY() to make code simpler

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -928,12 +928,10 @@ pgsk_planner(Query *parse,
 			else
 				result = standard_planner(parse, query_string, cursorOptions,
 										  boundParams);
-			plan_nested_level--;
 		}
-		PG_CATCH();
+		PG_FINALLY();
 		{
 			plan_nested_level--;
-			PG_RE_THROW();
 		}
 		PG_END_TRY();
 
@@ -1015,12 +1013,10 @@ pgsk_ExecutorRun(QueryDesc *queryDesc,
 #else
 			standard_ExecutorRun(queryDesc, direction, count);
 #endif
-		exec_nested_level--;
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		exec_nested_level--;
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
 }
@@ -1038,12 +1034,10 @@ pgsk_ExecutorFinish(QueryDesc *queryDesc)
 			prev_ExecutorFinish(queryDesc);
 		else
 			standard_ExecutorFinish(queryDesc);
-		exec_nested_level--;
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		exec_nested_level--;
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
 }


### PR DESCRIPTION
Since PG_CATCH() is used now, *_nested_level-- is written twice per function.
It's enough to call PG_FINNALY() because PG_CATCH() calls just PG_RE_THROW().

The pg_stat_statements extension use PG_FINALY() and the comments of
PG_FINALLY() in elog.h said the following.

> The cleanup code will be run in either case, and any error will be
> rethrown afterwards.