### PR TITLE
Change the unit from sec to millisec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,9 +67,9 @@ pg_stat_kcache view
 +==================+==================+=========================================================================================================================================================+
 | datname          | name             | Name of the database                                                                                                                                    |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_user_time   | double precision | User CPU time used planning statements in this database, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)      |
+| plan_user_time   | double precision | User CPU time used planning statements in this database, in milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)                  |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_system_time | double precision | System CPU time used planning  statements in this database, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)   |
+| plan_system_time | double precision | System CPU time used planning  statements in this database, in milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)               |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_minflts     | bigint           | Number of page reclaims (soft page faults) planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)          |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -95,9 +95,9 @@ pg_stat_kcache view
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_nivcsws     | bigint           | Number of involuntary context switches planning  statements in this database (if pg_stat_kcache.track_planning is enabled, otherwise zero)              |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| exec_user_time   | double precision | User CPU time used executing  statements in this database, in seconds and milliseconds                                                                  |
+| exec_user_time   | double precision | User CPU time used executing  statements in this database, in milliseconds                                                                              |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
-| exec_system_time | double precision | System CPU time used executing  statements in this database, in seconds and milliseconds                                                                |
+| exec_system_time | double precision | System CPU time used executing  statements in this database, in milliseconds                                                                            |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 | exec_minflts     | bigint           | Number of page reclaims (soft page faults) executing statements in this database                                                                        |
 +------------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -136,9 +136,9 @@ pg_stat_kcache_detail view
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | rolname          | name             | Role name                                                                                                                                |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_user_time   | double precision | User CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
+| plan_user_time   | double precision | User CPU time used planning the statement, in milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)                 |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_system_time | double precision | System CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)   |
+| plan_system_time | double precision | System CPU time used planning the statement, in milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)               |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_minflts     | bigint           | Number of page reclaims (soft page faults) planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)          |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
@@ -164,9 +164,9 @@ pg_stat_kcache_detail view
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_nivcsws     | bigint           | Number of involuntary context switches planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)              |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| exec_user_time   | double precision | User CPU time used executing the statement, in seconds and milliseconds                                                                  |
+| exec_user_time   | double precision | User CPU time used executing the statement, in milliseconds                                                                              |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| exec_system_time | double precision | System CPU time used executing the statement, in seconds and milliseconds                                                                |
+| exec_system_time | double precision | System CPU time used executing the statement, in milliseconds                                                                            |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | exec_minflts     | bigint           | Number of page reclaims (soft page faults) executing the statements                                                                      |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
@@ -221,9 +221,9 @@ It provides the following columns:
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | dbid             | oid              | Database OID                                                                                                                             |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_user_time   | double precision | User CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)     |
+| plan_user_time   | double precision | User CPU time used planning the statement, in milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)                 |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_system_time | double precision | System CPU time used planning the statement, in seconds and milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)   |
+| plan_system_time | double precision | System CPU time used planning the statement, in milliseconds (if pg_stat_kcache.track_planning is enabled, otherwise zero)               |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_minflts     | bigint           | Number of page reclaims (soft page faults) planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)          |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
@@ -249,9 +249,9 @@ It provides the following columns:
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_nivcsws     | bigint           | Number of involuntary context switches planning the statement (if pg_stat_kcache.track_planning is enabled, otherwise zero)              |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| exec_user_time   | double precision | User CPU time used executing the statement, in seconds and milliseconds                                                                  |
+| exec_user_time   | double precision | User CPU time used executing the statement, in milliseconds                                                                              |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| exec_system_time | double precision | System CPU time used executing the statement, in seconds and milliseconds                                                                |
+| exec_system_time | double precision | System CPU time used executing the statement, in milliseconds                                                                            |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | exec_minflts     | bigint           | Number of page reclaims (soft page faults) executing the statements                                                                      |
 +------------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------+

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -76,8 +76,8 @@ typedef uint32 pgsk_queryid;
  */
 #define RUSAGE_BLOCK_SIZE	512			/* Size of a block for getrusage() */
 
-#define TIMEVAL_DIFF(start, end) ((double) end.tv_sec + (double) end.tv_usec / 1000000.0) \
-	- ((double) start.tv_sec + (double) start.tv_usec / 1000000.0)
+#define TIMEVAL_DIFF(start, end) (((double) end.tv_sec + (double) end.tv_usec / 1000000.0) \
+	- ((double) start.tv_sec + (double) start.tv_usec / 1000000.0)) * 1000.0
 
 #if PG_VERSION_NUM < 140000
 #define ParallelLeaderBackendId ParallelMasterBackendId
@@ -129,8 +129,8 @@ typedef struct pgskCounters
 {
 	double			usage;		/* usage factor */
 	/* These fields are always used */
-	float8			utime;		/* CPU user time */
-	float8			stime;		/* CPU system time */
+	float8			utime;		/* CPU user time in msec */
+	float8			stime;		/* CPU system time in msec */
 #ifdef HAVE_GETRUSAGE
 	/* These fields are only used for platform with HAVE_GETRUSAGE defined */
 	int64			minflts;	/* page reclaims (soft page faults) */
@@ -421,7 +421,9 @@ pgsk_compute_counters(pgskCounters *counters,
 			if (queryDesc->totaltime->total < (3. / pgsk_linux_hz))
 			{
 				counters->stime = 0;
-				counters->utime = queryDesc->totaltime->total;
+
+				/* Change the unit from sec to msec */
+				counters->utime = queryDesc->totaltime->total * 1000.0;
 			}
 		}
 


### PR DESCRIPTION
Since pg_stat_kcache must be used with pg_stat_statements,
it is reasonable to use the same unit.

But, since there is an impact on users who already uses this extension,
It cannot be helped if the PR is rejected.