### PR TITLE
Fix compatibility with pg18

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -100,6 +100,14 @@ typedef uint32 pgsk_queryid;
 #define ParallelLeaderBackendId ParallelMasterBackendId
 #endif
 
+/* ExecutorStart hook */
+#if PG_VERSION_NUM >= 180000
+#define EXEC_START_RET bool
+#else
+#define EXEC_START_RET void
+#endif
+/* end of ExecutorStart hook */
+
 #define PGSK_MAX_NESTED_LEVEL		64
 
 /*
@@ -244,13 +252,7 @@ static PlannedStmt *pgsk_planner(Query *parse,
 								 int cursorOptions,
 								 ParamListInfo boundParams);
 #endif
-static
-#if PG_VERSION_NUM >= 180000
-bool
-#else
-void
-#endif
-pgsk_ExecutorStart(QueryDesc *queryDesc, int eflags);
+static EXEC_START_RET pgsk_ExecutorStart(QueryDesc *queryDesc, int eflags);
 static void pgsk_ExecutorRun(QueryDesc *queryDesc,
 				 ScanDirection direction,
 #if PG_VERSION_NUM >= 90600
@@ -1000,12 +1002,7 @@ pgsk_planner(Query *parse,
 }
 #endif
 
-static
-#if PG_VERSION_NUM >= 180000
-bool
-#else
-void
-#endif
+static EXEC_START_RET
 pgsk_ExecutorStart (QueryDesc *queryDesc, int eflags)
 {
 	if (pgsk_enabled(nesting_level))

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -102,9 +102,9 @@ typedef uint32 pgsk_queryid;
 
 /* ExecutorStart hook */
 #if PG_VERSION_NUM >= 180000
-#define EXEC_START_RET bool
+#define EXEC_START_RET	bool
 #else
-#define EXEC_START_RET void
+#define EXEC_START_RET	void
 #endif
 /* end of ExecutorStart hook */
 

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -244,7 +244,13 @@ static PlannedStmt *pgsk_planner(Query *parse,
 								 int cursorOptions,
 								 ParamListInfo boundParams);
 #endif
-static void pgsk_ExecutorStart(QueryDesc *queryDesc, int eflags);
+static
+#if PG_VERSION_NUM >= 180000
+bool
+#else
+void
+#endif
+pgsk_ExecutorStart(QueryDesc *queryDesc, int eflags);
 static void pgsk_ExecutorRun(QueryDesc *queryDesc,
 				 ScanDirection direction,
 #if PG_VERSION_NUM >= 90600
@@ -994,7 +1000,12 @@ pgsk_planner(Query *parse,
 }
 #endif
 
-static void
+static
+#if PG_VERSION_NUM >= 180000
+bool
+#else
+void
+#endif
 pgsk_ExecutorStart (QueryDesc *queryDesc, int eflags)
 {
 	if (pgsk_enabled(nesting_level))
@@ -1015,9 +1026,9 @@ pgsk_ExecutorStart (QueryDesc *queryDesc, int eflags)
 
 	/* give control back to PostgreSQL */
 	if (prev_ExecutorStart)
-		prev_ExecutorStart(queryDesc, eflags);
+		return prev_ExecutorStart(queryDesc, eflags);
 	else
-		standard_ExecutorStart(queryDesc, eflags);
+		return standard_ExecutorStart(queryDesc, eflags);
 }
 
 /*


### PR DESCRIPTION
Upstream commit postgres/postgres@525392d changed return type of ExecutorStart_hook API from void to bool.