### PR TITLE
Revert "Fix compatibility with pg18 (#51)"

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -100,14 +100,6 @@ typedef uint32 pgsk_queryid;
 #define ParallelLeaderBackendId ParallelMasterBackendId
 #endif
 
-/* ExecutorStart hook */
-#if PG_VERSION_NUM >= 180000
-#define EXEC_START_RET	bool
-#else
-#define EXEC_START_RET	void
-#endif
-/* end of ExecutorStart hook */
-
 #define PGSK_MAX_NESTED_LEVEL		64
 
 /*
@@ -252,7 +244,7 @@ static PlannedStmt *pgsk_planner(Query *parse,
 								 int cursorOptions,
 								 ParamListInfo boundParams);
 #endif
-static EXEC_START_RET pgsk_ExecutorStart(QueryDesc *queryDesc, int eflags);
+static void pgsk_ExecutorStart(QueryDesc *queryDesc, int eflags);
 static void pgsk_ExecutorRun(QueryDesc *queryDesc,
 				 ScanDirection direction,
 #if PG_VERSION_NUM >= 90600
@@ -1002,7 +994,7 @@ pgsk_planner(Query *parse,
 }
 #endif
 
-static EXEC_START_RET
+static void
 pgsk_ExecutorStart (QueryDesc *queryDesc, int eflags)
 {
 	if (pgsk_enabled(nesting_level))
@@ -1023,9 +1015,9 @@ pgsk_ExecutorStart (QueryDesc *queryDesc, int eflags)
 
 	/* give control back to PostgreSQL */
 	if (prev_ExecutorStart)
-		return prev_ExecutorStart(queryDesc, eflags);
+		prev_ExecutorStart(queryDesc, eflags);
 	else
-		return standard_ExecutorStart(queryDesc, eflags);
+		standard_ExecutorStart(queryDesc, eflags);
 }
 
 /*


### PR DESCRIPTION
This reverts commit 06c567c53fa00476848e634a807bf5b3bdabc8ff, as the underling upstream commit was reverted.

Thanks to Georgy Shelkovy for the report.