### PR TITLE
Fix 2.2.3--2.3.0 upgrade script

### DIFF
--- a/pg_stat_kcache--2.2.3--2.3.0.sql
+++ b/pg_stat_kcache--2.2.3--2.3.0.sql
@@ -7,8 +7,8 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION pg_stat_kcache" to load this file. \quit
 
-DROP VIEW pg_stat_kcache_detail;
 DROP VIEW pg_stat_kcache;
+DROP VIEW pg_stat_kcache_detail;
 DROP FUNCTION pg_stat_kcache();
 
 CREATE FUNCTION pg_stat_kcache(


### PR DESCRIPTION
As reported by github user 1165125080, the two initial "DROP VIEW" commands were in the wrong order, preventing upgrade from 2.2.3 to 2.3.0.

Note that this extension doesn't store any data in the SQL-level objects, so preiously users could already DROP the extension in version 2.2.3 and create it in version 2.3.0 as a workaround for this problem.