### PR TITLE
Postgres 19 support

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -407,14 +407,16 @@ pgsk_compute_counters(pgskCounters *counters,
 
 		if (queryDesc && queryDesc->totaltime)
 		{
-#if PG_VERSION_NUM >= 190000
-			double		total = (double) INSTR_TIME_GET_NANOSEC(queryDesc->totaltime->total);
-#else
-			double		total = queryDesc->totaltime->total;
-#endif
+			float8		total;
 
 			/* Make sure stats accumulation is done */
 			InstrEndLoop(queryDesc->totaltime);
+
+#if PG_VERSION_NUM >= 190000
+			total = INSTR_TIME_GET_DOUBLE(queryDesc->totaltime->total);
+#else
+			total = queryDesc->totaltime->total;
+#endif
 
 			/*
 			 * We only consider values greater than 3 * linux tick, otherwise the

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -407,6 +407,12 @@ pgsk_compute_counters(pgskCounters *counters,
 
 		if (queryDesc && queryDesc->totaltime)
 		{
+#if PG_VERSION_NUM >= 190000
+			double		total = INSTR_TIME_GET_MILLISEC(queryDesc->totaltime->total);
+#else
+			double		total = queryDesc->totaltime->total;
+#endif
+
 			/* Make sure stats accumulation is done */
 			InstrEndLoop(queryDesc->totaltime);
 
@@ -414,10 +420,10 @@ pgsk_compute_counters(pgskCounters *counters,
 			 * We only consider values greater than 3 * linux tick, otherwise the
 			 * bias is too big
 			 */
-			if (queryDesc->totaltime->total < (3. / pgsk_linux_hz))
+			if (total < (3. / pgsk_linux_hz))
 			{
 				counters->stime = 0;
-				counters->utime = queryDesc->totaltime->total;
+				counters->utime = total;
 			}
 		}
 

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -408,7 +408,7 @@ pgsk_compute_counters(pgskCounters *counters,
 		if (queryDesc && queryDesc->totaltime)
 		{
 #if PG_VERSION_NUM >= 190000
-			double		total = INSTR_TIME_GET_MILLISEC(queryDesc->totaltime->total);
+			double		total = (double) INSTR_TIME_GET_NANOSEC(queryDesc->totaltime->total);
 #else
 			double		total = queryDesc->totaltime->total;
 #endif

--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -405,7 +405,11 @@ pgsk_compute_counters(pgskCounters *counters,
 		counters->utime = TIMEVAL_DIFF(rusage_start->ru_utime, rusage_end->ru_utime);
 		counters->stime = TIMEVAL_DIFF(rusage_start->ru_stime, rusage_end->ru_stime);
 
+#if PG_VERSION_NUM >= 190000
+		if (queryDesc && queryDesc->query_instr)
+#else
 		if (queryDesc && queryDesc->totaltime)
+#endif
 		{
 			float8		total;
 
@@ -413,7 +417,7 @@ pgsk_compute_counters(pgskCounters *counters,
 			InstrEndLoop(queryDesc->totaltime);
 
 #if PG_VERSION_NUM >= 190000
-			total = INSTR_TIME_GET_DOUBLE(queryDesc->totaltime->total);
+			total = INSTR_TIME_GET_DOUBLE(queryDesc->query_instr->total);
 #else
 			total = queryDesc->totaltime->total;
 #endif


### PR DESCRIPTION
1) The commit postgres/postgres@e5a5e0a changed the total field type in the
Instrumentation structure from double to instr_time.

2) The postgres/postgres@2c16dee commit renamed the totaltime field in the
QueryDesc structure to query_instr.