### PR TITLE
Postgres 19 support

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -57,6 +57,9 @@
 #endif
 #include "storage/fd.h"
 #include "storage/ipc.h"
+#if PG_VERSION_NUM >= 190000
+#include "storage/lwlock.h"
+#endif
 #include "storage/spin.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"


### PR DESCRIPTION
The commit postgres/postgres@a2c8983 removed proc.h from shm_mq.h.