### PR TITLE
Fix postgres 19 support

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -43,6 +43,9 @@
 #include "access/parallel.h"
 #endif
 #include "executor/executor.h"
+#if PG_VERSION_NUM >= 190000
+#include "executor/instrument.h"
+#endif
 #include "funcapi.h"
 #include "miscadmin.h"
 #if PG_VERSION_NUM >= 130000
@@ -64,6 +67,9 @@
 #include "utils/pg_rusage.h"
 #endif
 #include "utils/timestamp.h"
+#if PG_VERSION_NUM >= 190000
+#include "utils/tuplestore.h"
+#endif
 
 #include "pg_stat_kcache.h"
 


### PR DESCRIPTION
1) Commit postgres/postgres@fba4233 removed include "executor/instrument.h" from
src/include/nodes/execnodes.h.

2) Commit postgres/postgres@fba4233 removed include "utils/tuplestore.h" from
src/include/nodes/execnodes.h.