### PR TITLE
Fix Postgres 19 support

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -515,7 +515,11 @@ pgsk_shmem_startup(void)
 
 	/* allocate stats shared memory hash */
 	pgsk_hash = ShmemInitHash("pg_stat_kcache hash",
+#if PG_VERSION_NUM >= 190000
+							  pgsk_max,
+#else
 							  pgsk_max, pgsk_max,
+#endif
 							  &info,
 							  HASH_ELEM | HASH_FUNCTION | HASH_COMPARE);
 


### PR DESCRIPTION
Commit postgres/postgres@9ebe1c4 replaced the two init_size and max_size
arguments in the ShmemInitHash function with a single nelems argument.