### PR TITLE
Fix Postgres 19 support

### DIFF
--- a/pg_stat_kcache.c
+++ b/pg_stat_kcache.c
@@ -407,8 +407,10 @@ pgsk_compute_counters(pgskCounters *counters,
 
 		if (queryDesc && queryDesc->totaltime)
 		{
+#if PG_VERSION_NUM < 190000
 			/* Make sure stats accumulation is done */
 			InstrEndLoop(queryDesc->totaltime);
+#endif
 
 			/*
 			 * We only consider values greater than 3 * linux tick, otherwise the


### PR DESCRIPTION
Commit postgres/postgres@5a79e78 stopped calling InstrEndLoop in ExecutorEnd
hooks.